### PR TITLE
Correção de palavras, texto e link

### DIFF
--- a/assets/data.js
+++ b/assets/data.js
@@ -20,7 +20,7 @@ module.exports = [
       'Faça no máximo 4 camadas por forma e leve para congelar.',
       'Retire do congelador, frite ou asse e está pronto.'
     ],
-    information: "Preaqueça a chapa, frigideira ou grelha por 10 minutos antes de levar os hambúrgueres. Adicione um pouquinho de óleo ou manteiga e não amasse os hambúrgueres! \n\n Você sabia que a receita que precede o hambúrguer surgiu no século XIII, na Europa? A ideia de moer a carne chegou em Hamburgo no século XVII, onde um açogueiro resolveu também temperá-la. Assim, a receita foi disseminada nos Estados Unidos por alemães da região. Lá surgiu a ideia de colocar o hambúrguer no meio do pão e adicionar outros ingredientes, como queijom tomates e alface."
+    information: "Preaqueça a chapa, frigideira ou grelha por 10 minutos antes de levar os hambúrgueres. Adicione um pouquinho de óleo ou manteiga e não amasse os hambúrgueres! \n\n Você sabia que a receita que precede o hambúrguer surgiu no século XIII, na Europa? A ideia de moer a carne chegou em Hamburgo no século XVII, onde um açogueiro resolveu também temperá-la. Assim, a receita foi disseminada nos Estados Unidos por alemães da região. Lá surgiu a ideia de colocar o hambúrguer no meio do pão e adicionar outros ingredientes, como queijo, tomates e alface."
   },
   {
     image: 'https://rocketseat-cdn.s3-sa-east-1.amazonaws.com/launchbase/receitas/pizza.png',
@@ -115,7 +115,7 @@ module.exports = [
     title: 'Docinhos pão-do-céu',
     author: 'Ricardo Golvea',
     ingredients: [
-      '1 kg de batata - doce',
+      '1 kg de batata-doce',
       '100 g de manteiga',
       '3 ovos',
       '1 pacote de coco seco ralado (100 g)',
@@ -126,9 +126,8 @@ module.exports = [
     ],
     preparation: [
       'Cozinhe a batata-doce numa panela de pressão, com meio litro de água, por cerca de 20 minutos. Descasque e passe pelo espremedor, ainda quente.',
-      'Junte a manteiga,os ovos, o coco ralado,o açúcar, o Leite Moça e o fermento em pó, mexendo bem após cada adição.',
-      'Despeje em assadeira retangular média, untada e leve ao forno médio (180°C), por aproximadamente 45 minutos. Depois de frio, polvilhe, com o',
-      'açúcar de confeiteiro e corte em quadrados.'
+      'Junte a manteiga, os ovos, o coco ralado, o açúcar, o Leite Moça e o fermento em pó, mexendo bem após cada adição.',
+      'Despeje em assadeira retangular média, untada e leve ao forno médio (180°C), por aproximadamente 45 minutos. Depois de frio, polvilhe, com o açúcar de confeiteiro e corte em quadrados.'
     ],
     information: ''
   }

--- a/assets/data.js
+++ b/assets/data.js
@@ -20,7 +20,7 @@ module.exports = [
       'Faça no máximo 4 camadas por forma e leve para congelar.',
       'Retire do congelador, frite ou asse e está pronto.'
     ],
-    information: "Preaqueça a chapa, frigideira ou grelha por 10 minutos antes de levar os hambúrgueres. Adicione um pouquinho de óleo ou manteiga e não amasse os hambúrgueres! \n\n Você sabia que a receita que precede o hambúrguer surgiu no século XIII, na Europa? A ideia de moer a carne chegou em Hamburgo no século XVII, onde um açogueiro resolveu também temperá-la. Assim, a receita foi disseminada nos Estados Unidos por alemães da região. Lá surgiu a ideia de colocar o hambúrguer no meio do pão e adicionar outros ingredientes, como queijo, tomates e alface."
+    information: "Preaqueça a chapa, frigideira ou grelha por 10 minutos antes de levar os hambúrgueres. Adicione um pouquinho de óleo ou manteiga e não amasse os hambúrgueres! \n\n Você sabia que a receita que precede o hambúrguer surgiu no século XIII, na Europa? A ideia de moer a carne chegou em Hamburgo no século XVII, onde um açougueiro resolveu também temperá-la. Assim, a receita foi disseminada nos Estados Unidos por alemães da região. Lá surgiu a ideia de colocar o hambúrguer no meio do pão e adicionar outros ingredientes, como queijo, tomates e alface."
   },
   {
     image: 'https://rocketseat-cdn.s3-sa-east-1.amazonaws.com/launchbase/receitas/pizza.png',

--- a/desafios/03-1-primeiro-servidor.md
+++ b/desafios/03-1-primeiro-servidor.md
@@ -40,7 +40,7 @@ _Erro 404 é comum aparecer em páginas da internet, quando não foi encontrado 
 - `not-found.njk`: Arquivo referente à pagina de erro 404, deve ser servido quando for realizada uma requisição à uma página que não existe. Esse arquivo deve ter:
 
   - Layout.njk como base
-  - Ter um texto infortivo sobre o erro
+  - Ter um texto informativo sobre o erro
 
   Dica: Para capturar essas requisições, basta adicionar esse trecho após **todas** as rotas no seu `server.js`:
 

--- a/desafios/03-3-pagina-descricao-curso.md
+++ b/desafios/03-3-pagina-descricao-curso.md
@@ -51,7 +51,7 @@ server.get("/courses/:id", function(req, res) {
 ### Fórum
 
 Se houver mais dúvida sobre o desafio, essa thread no fórum poderá ser útil para você 💜 
-https://skylab.rocketseat.com.br/h/forum/launchbase/07c66e6d-06ff-4cfb-baf2-b5b27be6ac8b
+https://app.rocketseat.com.br/h/forum/launchbase/07c66e6d-06ff-4cfb-baf2-b5b27be6ac8b
 
 ### Estilização
 


### PR DESCRIPTION
- Corrigido a palavra `açogueiro` para `açougueiro`.
- Corrigido a palavra `batata - doce` para batata-doce`. 
- Corrigido trecho da frase `como queijom tomates e alface` para `como queijo, tomates e alface`.
- Corrigido a quebra de linha, onde deveria ser continuação da frase.
- Corrigido a palavra `infortivo` para `informativo`.
- Corrigido o link para o fórum do Skylab que estava quebrado.